### PR TITLE
feat: Set RepeatMasker species and disable ALR/Alpha restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Multiple samples can be provided via the configfile. Each sample should contain 
 ## Parameters
 |parameter|description|default|
 |-|-|-|
+|`species`|Species to use for RepeatMasker Dfam database. **CDR-Finder was designed for human centromeres so performance in other species is untested. Use with caution.** See https://www.repeatmasker.org/genomicDatasets/RMGenomicDatasets.html.|human|
+|`restrict_alr`|Restrict CDR search to sequence annotated as `ALR/Alpha` by RepeatMasker. **Disabling this will cause false positives and should only be set to `false` if the input region is well curated.**|true|
 |`window_size`|Size of the methylation windows to average over.|5000|
 |`alr_threshold`|Size of ALR repeat stretches to include in search of CDR.|100,000|
 |`bp_merge`|Distance in bases to merge adjacent CDRs. Can be omitted.|1|

--- a/README.md
+++ b/README.md
@@ -140,3 +140,6 @@ make docker
 ```bash
 make singularity
 ```
+
+## Cite
+* Glennis A Logsdon, F Kumara Mastrorosa, Keisuke K Oshima, Allison N Rozanski, William T Harvey, Evan E Eichler, Identification and annotation of centromeric hypomethylated regions with Centromere Dip Region (CDR)-Finder, Bioinformatics, 2024;, btae733, https://doi.org/10.1093/bioinformatics/btae733*

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ samples:
 species: "human"
 
 # Restrict to alpha-satellite repeat annotated sequence.
-# NOTE: This will give false positives if the region is not well curated.
+# NOTE: If disabled, this will give false positives if the region is not well curated.
 restrict_alr: true
 
 # Size of the methylation windows to average over

--- a/test/config/config_no_alr_intersect.yaml
+++ b/test/config/config_no_alr_intersect.yaml
@@ -1,16 +1,16 @@
 samples:
   CHM13:
-    fasta: T2T-CHM13v2.fasta
-    regions: target_region.bed
-    bam: T2T-CHM13v2.bam
+    fasta: test/data/fa/CHM13_chr8_chr21.fa.gz
+    regions: test/data/bed/CHM13_cen_500kbp.bed
+    bam: test/data/bam/CHM13_chr8_chr21.bam
+    # Add plot titles
+    titles: test/data/bed/titles.tsv
 
 # Species to use for RepeatMasker
-# See https://www.repeatmasker.org/genomicDatasets/RMGenomicDatasets.html
 species: "human"
 
 # Restrict to alpha-satellite repeat annotated sequence.
-# NOTE: This will give false positives if the region is not well curated.
-restrict_alr: true
+restrict_alr: false
 
 # Size of the methylation windows to average over
 window_size: 5000
@@ -31,7 +31,4 @@ bp_alr_merge: 1000
 
 bp_edge: 500000
 
-extend_edges_std: -1
-
-# Add red horizontal bar where CDR is.
-add_hbar: true
+extend_edges_std: null

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -147,7 +147,7 @@ rule run_rm:
         join(BMK_DIR, "run_rm_{sample}.tsv")
     params:
         engine="rmblast",
-        species="human",
+        species=config.get("species", "human"),
         output_dir=lambda wc, output: os.path.dirname(str(output)),
     resources:
         mem=8,
@@ -332,7 +332,12 @@ rule intersect_RM:
 rule call_cdrs:
     input:
         script=workflow.source_path("scripts/cdr_finder.py"),
-        intersect_bed=rules.intersect_RM.output.intersect_bed,
+        methyl_bed=(
+            rules.intersect_RM.output.intersect_bed
+            if config.get("restrict_alr")
+            else
+            rules.add_target_bed_coords_windows.output
+        ),
     output:
         cdrs=join(OUTPUT_DIR, "bed", "{sample}_CDR.bed"),
     log:
@@ -361,7 +366,7 @@ rule call_cdrs:
     shell:
         """
         python {input.script} \
-        -i {input.intersect_bed} \
+        -i {input.methyl_bed} \
         --thr_height_perc_valley {params.thr_height_perc_valley} \
         --bp_edge {params.bp_edge} \
         --edge_height_heuristic {params.edge_height_heuristic} \


### PR DESCRIPTION
* Added the option `species` for Repeatmasker library species.
* Added the option `restrict_alr` to skip ALR region intersection.
* Updated docs.